### PR TITLE
introduce NetworkError for devportalservice package

### DIFF
--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -133,7 +133,10 @@ func convertDesCookie(cookies []cookie) ([]string, error) {
 		convertedCookies = append(convertedCookies, b.String()+"\n")
 	}
 
-	return convertedCookies, errors.New(strings.Join(errs, "\n"))
+	if len(errs) > 0 {
+		return nil, errors.New(strings.Join(errs, "\n"))
+	}
+	return convertedCookies, nil
 }
 
 func performRequest(req *http.Request, requestResponse interface{}) ([]byte, error) {

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -3,6 +3,7 @@ package devportalservice
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +13,12 @@ import (
 
 	"github.com/bitrise-io/go-utils/log"
 )
+
+// NetworkError ...
+type NetworkError struct {
+	Status int
+	Body   string
+}
 
 // portalData ...
 type portalData struct {
@@ -36,15 +43,21 @@ type cookie struct {
 
 // SessionData will fetch the session from Bitrise for the connected Apple developer account
 // If the BITRISE_PORTAL_DATA_JSON is provided (for debug purposes) it will use that instead.
-func SessionData() (string, []error) {
+func SessionData() (string, error) {
 	p, err := getDeveloperPortalData(os.Getenv("BITRISE_BUILD_URL"), os.Getenv("BITRISE_BUILD_API_TOKEN"))
 	if err != nil {
-		return "", []error{err}
+		return "", err
 	}
 
-	cookies, errors := convertDesCookie(p.SessionCookies["https://idmsa.apple.com"])
-	session := strings.Join(cookies, "")
-	return session, errors
+	cookies, err := convertDesCookie(p.SessionCookies["https://idmsa.apple.com"])
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(cookies, ""), nil
+}
+
+func (e NetworkError) Error() string {
+	return fmt.Sprintf("response %d %s", e.Status, e.Body)
 }
 
 func getDeveloperPortalData(buildURL, buildAPIToken string) (portalData, error) {
@@ -71,14 +84,14 @@ func getDeveloperPortalData(buildURL, buildAPIToken string) (portalData, error) 
 	req.Header.Add("BUILD_API_TOKEN", buildAPIToken)
 
 	if _, err := performRequest(req, &p); err != nil {
-		return portalData{}, fmt.Errorf("Falied to fetch portal data from Bitrise, error: %s", err)
+		return portalData{}, err
 	}
 	return p, nil
 }
 
-func convertDesCookie(cookies []cookie) ([]string, []error) {
+func convertDesCookie(cookies []cookie) ([]string, error) {
 	var convertedCookies []string
-	var errors []error
+	var errs []string
 	for _, c := range cookies {
 		if convertedCookies == nil {
 			convertedCookies = append(convertedCookies, "---"+"\n")
@@ -97,21 +110,21 @@ func convertDesCookie(cookies []cookie) ([]string, []error) {
   path: "{{.Path}}"
 `)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("Failed to create golang template for the cookie: %v", c))
+			errs = append(errs, fmt.Sprintf("failed to create golang template for the cookie: %v", c))
 			continue
 		}
 
 		var b bytes.Buffer
 		err = tmpl.Execute(&b, c)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("Failed to parse cookie: %v", c))
+			errs = append(errs, fmt.Sprintf("failed to parse cookie: %v", c))
 			continue
 		}
 
 		convertedCookies = append(convertedCookies, b.String()+"\n")
 	}
 
-	return convertedCookies, errors
+	return convertedCookies, errors.New(strings.Join(errs, "\n"))
 }
 
 func performRequest(req *http.Request, requestResponse interface{}) ([]byte, error) {
@@ -135,7 +148,7 @@ func performRequest(req *http.Request, requestResponse interface{}) ([]byte, err
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Response status: %d - Body: %s", response.StatusCode, string(body))
+		return nil, NetworkError{Status: response.StatusCode, Body: string(body)}
 	}
 
 	// Parse JSON body

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-// NetworkError ...
+// NetworkError represents a networking issue.
 type NetworkError struct {
 	Status int
 	Body   string
@@ -24,7 +24,8 @@ func (e NetworkError) Error() string {
 	return fmt.Sprintf("response %d %s", e.Status, e.Body)
 }
 
-// CIEnvMissingError ...
+// CIEnvMissingError represents an issue caused by missing environment variables,
+// which environment variables are exposed in builds on Bitrise.io.
 type CIEnvMissingError struct {
 	Key string
 }

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -159,11 +159,8 @@ func Test_convertDesCookie(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, errors := convertDesCookie(tt.cookies); errors != nil {
-				t.Errorf("Failed to get the session for the Apple Developer Portal, errors:")
-				for _, err := range errors {
-					t.Errorf("%s\n", err)
-				}
+			if got, err := convertDesCookie(tt.cookies); err != nil {
+				t.Errorf("Failed to get the session for the Apple Developer Portal, error: %s", err)
 			} else if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("convertDesCookie() = \n%v, want \n%v", got, tt.want)
 			}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -226,16 +227,20 @@ func main() {
 
 	//
 	// Fastlane session
-	fmt.Println()
-	log.Infof("Ensure cookies for Apple Developer Portal")
-
-	fs, errors := devportalservice.SessionData()
-	if errors != nil {
-		log.Warnf("Failed to activate the Bitrise Apple Developer Portal connection: %s\nRead more: https://devcenter.bitrise.io/getting-started/connecting-apple-dev-account/ \nerrors:")
-		for _, err := range errors {
-			log.Errorf("%s\n", err)
+	fs, err := devportalservice.SessionData()
+	if err != nil {
+		if networkErr, ok := err.(devportalservice.NetworkError); ok && networkErr.Status == http.StatusNotFound {
+			log.Debugf("")
+			log.Debugf("Connected Apple Developer Portal Account not found")
+		} else {
+			fmt.Println()
+			log.Errorf("Failed to activate Bitrise Apple Developer Portal connection: %s", err)
+			log.Warnf("Read more: https://devcenter.bitrise.io/getting-started/connecting-apple-dev-account/")
 		}
 	} else {
+		fmt.Println()
+		log.Infof("Connected Apple Developer Portal Account found, exposing FASTLANE_SESSION env var")
+
 		if err := tools.ExportEnvironmentWithEnvman("FASTLANE_SESSION", fs); err != nil {
 			fail("Failed to export FASTLANE_SESSION, error: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ type configs struct {
 	GemfilePath     string `env:"gemfile_path"`
 	FastlaneVersion string `env:"fastlane_version"`
 	ITMSParameters  string `env:"itms_upload_parameters"`
+
+	VerboseLog bool `env:"verbose_log,opt[yes,no]"`
 }
 
 func fail(format string, v ...interface{}) {
@@ -214,6 +216,7 @@ func main() {
 	}
 
 	stepconf.Print(cfg)
+	log.SetEnableDebugLog(cfg.VerboseLog)
 
 	//
 	// Validate inputs

--- a/step.yml
+++ b/step.yml
@@ -188,3 +188,12 @@ inputs:
         In case you are behind a firewall, you can specify a different transporter protocol using this input.
 
         Read more on Apple [Transporter User Guide](https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126).
+  - verbose_log: "no"
+    opts:
+      category: Debug
+      title: "Enable verbose logging?"
+      description: Enable verbose logging?
+      is_required: true
+      value_options:
+      - "yes"
+      - "no"


### PR DESCRIPTION
1. Based on [Error handling and Go](https://blog.golang.org/error-handling-and-go) I introduced error types to distinguish different error cases:
- NetworkError means there was a networking issue with the Bitrise API, status code not found can be spotted using this error type
- CIEnvMissingError means necessary envs are missing for the dev portal connection, usually in case of local run

2. convertDesCookie func returns a single error by joining particular errors, since we used them this way: https://github.com/bitrise-steplib/steps-deploy-to-itunesconnect-deliver/blob/master/main.go#L234-L237 and https://github.com/bitrise-steplib/steps-fastlane/blob/master/main.go#L110-L113

3. devportalservice.SessionData error handled regarding to the error type

4. verbose_log input introduced