### PR TITLE
Apple dev conn

### DIFF
--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -68,6 +68,7 @@ func (c *BitriseClient) GetAppleDeveloperConnection(buildURL, buildAPIToken stri
 
 	type data struct {
 		*SessionBasedConnection
+		TestDevices []TestDevice `json:"test_devices"`
 	}
 	var d data
 	if err := json.Unmarshal([]byte(body), &d); err != nil {
@@ -76,6 +77,7 @@ func (c *BitriseClient) GetAppleDeveloperConnection(buildURL, buildAPIToken stri
 
 	return &AppleDeveloperConnection{
 		SessionBasedConnection: d.SessionBasedConnection,
+		TestDevices:            d.TestDevices,
 	}, nil
 }
 
@@ -99,10 +101,22 @@ type SessionBasedConnection struct {
 	SessionCookies       map[string][]cookie `json:"session_cookies"`
 }
 
+// TestDevice ...
+type TestDevice struct {
+	ID         int    `json:"id"`
+	UserID     int    `json:"user_id"`
+	DeviceID   string `json:"device_identifier"`
+	Title      string `json:"title"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+	DeviceType string `json:"device_type"`
+}
+
 // AppleDeveloperConnection represents a Bitrise.io Apple Developer connection.
 // https://devcenter.bitrise.io/getting-started/configuring-bitrise-steps-that-require-apple-developer-account-data/
 type AppleDeveloperConnection struct {
 	SessionBasedConnection *SessionBasedConnection
+	TestDevices            []TestDevice `json:"test_devices"`
 }
 
 // Expiry returns the expiration of the Bitrise session-based Apple Developer connection.

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -68,6 +68,7 @@ func (c *BitriseClient) GetAppleDeveloperConnection(buildURL, buildAPIToken stri
 
 	type data struct {
 		*SessionBasedConnection
+		*JWTConnection
 		TestDevices []TestDevice `json:"test_devices"`
 	}
 	var d data
@@ -77,6 +78,7 @@ func (c *BitriseClient) GetAppleDeveloperConnection(buildURL, buildAPIToken stri
 
 	return &AppleDeveloperConnection{
 		SessionBasedConnection: d.SessionBasedConnection,
+		JWTConnection:          d.JWTConnection,
 		TestDevices:            d.TestDevices,
 	}, nil
 }
@@ -101,6 +103,13 @@ type SessionBasedConnection struct {
 	SessionCookies       map[string][]cookie `json:"session_cookies"`
 }
 
+// JWTConnection ...
+type JWTConnection struct {
+	KeyID      string `json:"key_id"`
+	IssuerID   string `json:"issuer_id"`
+	PrivateKey string `json:"private_key"`
+}
+
 // TestDevice ...
 type TestDevice struct {
 	ID         int    `json:"id"`
@@ -116,6 +125,7 @@ type TestDevice struct {
 // https://devcenter.bitrise.io/getting-started/configuring-bitrise-steps-that-require-apple-developer-account-data/
 type AppleDeveloperConnection struct {
 	SessionBasedConnection *SessionBasedConnection
+	JWTConnection          *JWTConnection
 	TestDevices            []TestDevice `json:"test_devices"`
 }
 

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -13,11 +13,6 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-const (
-	bitriseBuildURLKey      = "BITRISE_BUILD_URL"
-	bitriseBuildAPITokenKey = "BITRISE_BUILD_API_TOKEN"
-)
-
 type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -67,7 +67,7 @@ func (c *BitriseClient) GetAppleDeveloperConnection(buildURL, buildAPIToken stri
 	}
 
 	type data struct {
-		*SessionBasedConnection
+		*SessionConnection
 		*JWTConnection
 		TestDevices []TestDevice `json:"test_devices"`
 	}
@@ -77,9 +77,9 @@ func (c *BitriseClient) GetAppleDeveloperConnection(buildURL, buildAPIToken stri
 	}
 
 	return &AppleDeveloperConnection{
-		SessionBasedConnection: d.SessionBasedConnection,
-		JWTConnection:          d.JWTConnection,
-		TestDevices:            d.TestDevices,
+		SessionConnection: d.SessionConnection,
+		JWTConnection:     d.JWTConnection,
+		TestDevices:       d.TestDevices,
 	}, nil
 }
 
@@ -95,8 +95,8 @@ type cookie struct {
 	ForDomain *bool  `json:"for_domain,omitempty"`
 }
 
-// SessionBasedConnection represents a Bitrise.io session-based Apple Developer connection.
-type SessionBasedConnection struct {
+// SessionConnection represents a Bitrise.io session-based Apple Developer connection.
+type SessionConnection struct {
 	AppleID              string              `json:"apple_id"`
 	Password             string              `json:"password"`
 	ConnectionExpiryDate string              `json:"connection_expiry_date"`
@@ -124,13 +124,13 @@ type TestDevice struct {
 // AppleDeveloperConnection represents a Bitrise.io Apple Developer connection.
 // https://devcenter.bitrise.io/getting-started/configuring-bitrise-steps-that-require-apple-developer-account-data/
 type AppleDeveloperConnection struct {
-	SessionBasedConnection *SessionBasedConnection
-	JWTConnection          *JWTConnection
-	TestDevices            []TestDevice `json:"test_devices"`
+	SessionConnection *SessionConnection
+	JWTConnection     *JWTConnection
+	TestDevices       []TestDevice `json:"test_devices"`
 }
 
 // Expiry returns the expiration of the Bitrise session-based Apple Developer connection.
-func (c *SessionBasedConnection) Expiry() *time.Time {
+func (c *SessionConnection) Expiry() *time.Time {
 	t, err := time.Parse(time.RFC3339, c.ConnectionExpiryDate)
 	if err != nil {
 		log.Warnf("Could not parse session-based connection expiry date: %s", err)
@@ -140,7 +140,7 @@ func (c *SessionBasedConnection) Expiry() *time.Time {
 }
 
 // Expired returns whether the Bitrise session-based Apple Developer connection is expired.
-func (c *SessionBasedConnection) Expired() bool {
+func (c *SessionConnection) Expired() bool {
 	expiry := c.Expiry()
 	if expiry == nil {
 		return false
@@ -150,7 +150,7 @@ func (c *SessionBasedConnection) Expired() bool {
 
 // FastlaneLoginSession returns the Apple ID login session in a ruby/object:HTTP::Cookie format.
 // The session can be used as a value for FASTLANE_SESSION environment variable: https://docs.fastlane.tools/best-practices/continuous-integration/#two-step-or-two-factor-auth.
-func (c *SessionBasedConnection) FastlaneLoginSession() (string, error) {
+func (c *SessionConnection) FastlaneLoginSession() (string, error) {
 	var rubyCookies []string
 	for _, cookie := range c.SessionCookies["https://idmsa.apple.com"] {
 		if rubyCookies == nil {

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -47,6 +47,15 @@ func TestGetAppleDeveloperConnection(t *testing.T) {
 			want:    &testSessionBasedConnection,
 			wantErr: false,
 		},
+		{
+			name: "JWT Apple Developer Connection set for the build",
+			response: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(testJWTConnectionResponseBody)),
+			},
+			want:    &testJWTConnecton,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -35,16 +35,16 @@ func TestGetAppleDeveloperConnection(t *testing.T) {
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(strings.NewReader(testDevicesResponseBody)),
 			},
-			want:    &testDevicesAppleDevConnData,
+			want:    &testDevices,
 			wantErr: false,
 		},
 		{
 			name: "Session-based Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testAppleDevConnDataJSON)),
+				Body:       ioutil.NopCloser(strings.NewReader(testSessionBasedConnectionResponseBody)),
 			},
-			want:    &testAppleDevConnData,
+			want:    &testSessionBasedConnection,
 			wantErr: false,
 		},
 	}
@@ -81,9 +81,9 @@ func TestSessionEnvValue(t *testing.T) {
 			name: "Session-based Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testAppleDevConnDataJSON)),
+				Body:       ioutil.NopCloser(strings.NewReader(testSessionBasedConnectionResponseBody)),
 			},
-			want:    testAppleDevConnSession,
+			want:    testFastlaneSession,
 			wantErr: false,
 		},
 	}

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -50,13 +50,6 @@ func TestSessionEnvValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			urlRestoreFunc := restorableSetEnv(t, bitriseBuildURLKey, "dummy url")
-			tokenRestoreFunc := restorableSetEnv(t, bitriseBuildAPITokenKey, "dummy token")
-			defer func() {
-				urlRestoreFunc()
-				tokenRestoreFunc()
-			}()
-
 			c := NewBitriseClient(newMockHTTPClient(tt.response, nil))
 			conn, err := c.GetAppleDeveloperConnection("dummy url", "dummy token")
 			require.NoError(t, err)

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -35,16 +35,16 @@ func TestGetAppleDeveloperConnection(t *testing.T) {
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(strings.NewReader(testDevicesResponseBody)),
 			},
-			want:    &testDevices,
+			want:    &testConnectionOnlyDevices,
 			wantErr: false,
 		},
 		{
 			name: "Session-based Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testSessionBasedConnectionResponseBody)),
+				Body:       ioutil.NopCloser(strings.NewReader(testSessionConnectionResponseBody)),
 			},
-			want:    &testSessionBasedConnection,
+			want:    &testConnectionWithSessionConnection,
 			wantErr: false,
 		},
 		{
@@ -53,7 +53,16 @@ func TestGetAppleDeveloperConnection(t *testing.T) {
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(strings.NewReader(testJWTConnectionResponseBody)),
 			},
-			want:    &testJWTConnecton,
+			want:    &testConnectionWithJWTConnection,
+			wantErr: false,
+		},
+		{
+			name: "Session-based and JWT Apple Developer Connection set for the build, test device available",
+			response: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(testSessionAndJWTConnectionResponseBody)),
+			},
+			want:    &testConnectionWithSessionAndJWTConnection,
 			wantErr: false,
 		},
 	}
@@ -90,7 +99,7 @@ func TestSessionEnvValue(t *testing.T) {
 			name: "Session-based Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testSessionBasedConnectionResponseBody)),
+				Body:       ioutil.NopCloser(strings.NewReader(testSessionConnectionResponseBody)),
 			},
 			want:    testFastlaneSession,
 			wantErr: false,
@@ -103,11 +112,11 @@ func TestSessionEnvValue(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.want == "" {
-				require.Nil(t, conn.SessionBasedConnection)
+				require.Nil(t, conn.SessionConnection)
 				return
 			}
 
-			got, err := conn.SessionBasedConnection.FastlaneLoginSession()
+			got, err := conn.SessionConnection.FastlaneLoginSession()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SessionData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -54,7 +54,12 @@ func TestSessionEnvValue(t *testing.T) {
 			conn, err := c.GetAppleDeveloperConnection("dummy url", "dummy token")
 			require.NoError(t, err)
 
-			got, err := conn.FastlaneLoginSession()
+			if tt.want == "" {
+				require.Nil(t, conn.SessionBasedConnection)
+				return
+			}
+
+			got, err := conn.SessionBasedConnection.FastlaneLoginSession()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SessionData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -10,6 +10,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetAppleDeveloperConnection(t *testing.T) {
+	tests := []struct {
+		name string
+
+		response *http.Response
+		err      error
+
+		want    *AppleDeveloperConnection
+		wantErr bool
+	}{
+		{
+			name: "No Apple Developer Connection set for the build",
+			response: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader("{}")),
+			},
+			want:    &AppleDeveloperConnection{},
+			wantErr: false,
+		},
+		{
+			name: "No Apple Developer Connection set for the build, test devices available",
+			response: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(testDevicesResponseBody)),
+			},
+			want:    &testDevicesAppleDevConnData,
+			wantErr: false,
+		},
+		{
+			name: "Session-based Apple Developer Connection set for the build",
+			response: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(testAppleDevConnDataJSON)),
+			},
+			want:    &testAppleDevConnData,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewBitriseClient(newMockHTTPClient(tt.response, nil))
+			got, err := c.GetAppleDeveloperConnection("dummy url", "dummy token")
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSessionEnvValue(t *testing.T) {
 	tests := []struct {
 		name string
@@ -25,15 +73,6 @@ func TestSessionEnvValue(t *testing.T) {
 			response: &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(strings.NewReader("{}")),
-			},
-			want:    "",
-			wantErr: false,
-		},
-		{
-			name: "No Apple Developer Connection set for the build, test devices available",
-			response: &http.Response{
-				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testDevicesResponseBody)),
 			},
 			want:    "",
 			wantErr: false,

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -82,28 +82,30 @@ const testAppleDevConnDataJSON = `{
 }`
 
 var testAppleDevConnData = AppleDeveloperConnection{
-	AppleID:              "example@example.io",
-	Password:             "highSecurityPassword",
-	ConnectionExpiryDate: "2019-04-06T12:04:59.000Z",
-	SessionCookies: map[string][]cookie{
-		"https://idmsa.apple.com": {
-			{
-				Name:     "DES58b0eba556d80ed2b98707e15ffafd344",
-				Path:     "/",
-				Value:    "HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT",
-				Domain:   "idmsa.apple.com",
-				Secure:   true,
-				Expires:  "2019-04-06T12:04:59Z",
-				MaxAge:   2592000,
-				Httponly: true,
-			},
-			{
-				Name:     "myacinfo",
-				Path:     "/",
-				Value:    "DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc",
-				Domain:   "apple.com",
-				Secure:   true,
-				Httponly: true,
+	SessionBasedConnection: &SessionBasedConnection{
+		AppleID:              "example@example.io",
+		Password:             "highSecurityPassword",
+		ConnectionExpiryDate: "2019-04-06T12:04:59.000Z",
+		SessionCookies: map[string][]cookie{
+			"https://idmsa.apple.com": {
+				{
+					Name:     "DES58b0eba556d80ed2b98707e15ffafd344",
+					Path:     "/",
+					Value:    "HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT",
+					Domain:   "idmsa.apple.com",
+					Secure:   true,
+					Expires:  "2019-04-06T12:04:59Z",
+					MaxAge:   2592000,
+					Httponly: true,
+				},
+				{
+					Name:     "myacinfo",
+					Path:     "/",
+					Value:    "DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc",
+					Domain:   "apple.com",
+					Secure:   true,
+					Httponly: true,
+				},
 			},
 		},
 	},

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -24,7 +24,7 @@ const testDevicesResponseBody = `{
 }
 `
 
-var testDevicesAppleDevConnData = AppleDeveloperConnection{
+var testDevices = AppleDeveloperConnection{
 	TestDevices: []TestDevice{
 		{
 			ID:         24,
@@ -47,24 +47,7 @@ var testDevicesAppleDevConnData = AppleDeveloperConnection{
 	},
 }
 
-const testAppleDevConnSession = `---
-- !ruby/object:HTTP::Cookie
-  name: DES58b0eba556d80ed2b98707e15ffafd344
-  value: HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT
-  domain: idmsa.apple.com
-  for_domain: true
-  path: "/"
-
-- !ruby/object:HTTP::Cookie
-  name: myacinfo
-  value: DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc
-  domain: apple.com
-  for_domain: true
-  path: "/"
-
-`
-
-const testAppleDevConnDataJSON = `{
+const testSessionBasedConnectionResponseBody = `{
     "apple_id": "example@example.io",
     "password": "highSecurityPassword",
     "connection_expiry_date": "2019-04-06T12:04:59.000Z",
@@ -92,7 +75,24 @@ const testAppleDevConnDataJSON = `{
     }
 }`
 
-var testAppleDevConnData = AppleDeveloperConnection{
+const testFastlaneSession = `---
+- !ruby/object:HTTP::Cookie
+  name: DES58b0eba556d80ed2b98707e15ffafd344
+  value: HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT
+  domain: idmsa.apple.com
+  for_domain: true
+  path: "/"
+
+- !ruby/object:HTTP::Cookie
+  name: myacinfo
+  value: DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc
+  domain: apple.com
+  for_domain: true
+  path: "/"
+
+`
+
+var testSessionBasedConnection = AppleDeveloperConnection{
 	SessionBasedConnection: &SessionBasedConnection{
 		AppleID:              "example@example.io",
 		Password:             "highSecurityPassword",

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -24,6 +24,29 @@ const testDevicesResponseBody = `{
 }
 `
 
+var testDevicesAppleDevConnData = AppleDeveloperConnection{
+	TestDevices: []TestDevice{
+		{
+			ID:         24,
+			UserID:     4,
+			DeviceID:   "asdf12345ad9b298cb9a9f28555c49573d8bc322",
+			Title:      "iPhone 6",
+			CreatedAt:  "2015-03-13T16:16:13.665Z",
+			UpdatedAt:  "2015-03-13T16:16:13.665Z",
+			DeviceType: "ios",
+		},
+		{
+			ID:         28,
+			UserID:     4,
+			DeviceID:   "asdf12341e73b76df6e99d0d713133c3e078418f",
+			Title:      "iPad mini 2 (Wi-Fi)",
+			CreatedAt:  "2015-03-19T13:25:43.487Z",
+			UpdatedAt:  "2015-03-19T13:25:43.487Z",
+			DeviceType: "ios",
+		},
+	},
+}
+
 const testAppleDevConnSession = `---
 - !ruby/object:HTTP::Cookie
   name: DES58b0eba556d80ed2b98707e15ffafd344
@@ -66,19 +89,7 @@ const testAppleDevConnDataJSON = `{
                 "httponly": true
             }
         ]
-    },
-    "test_devices": [
-        {
-            "id": 8414,
-            "user_id": 52411,
-            "device_identifier": "1b78ac4bad2e8911139287ac5dd152fbe86eb2b9",
-            "title": "iPhone 7",
-            "created_at": "2018-08-30T09:09:36.332Z",
-            "updated_at": "2018-08-30T09:09:36.332Z",
-            "device_type": "ios"
-        }
-    ],
-    "default_team_id": null
+    }
 }`
 
 var testAppleDevConnData = AppleDeveloperConnection{

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -24,32 +24,34 @@ const testDevicesResponseBody = `{
 }
 `
 
-var testDevices = AppleDeveloperConnection{
-	SessionBasedConnection: nil,
-	JWTConnection:          nil,
-	TestDevices: []TestDevice{
-		{
-			ID:         24,
-			UserID:     4,
-			DeviceID:   "asdf12345ad9b298cb9a9f28555c49573d8bc322",
-			Title:      "iPhone 6",
-			CreatedAt:  "2015-03-13T16:16:13.665Z",
-			UpdatedAt:  "2015-03-13T16:16:13.665Z",
-			DeviceType: "ios",
-		},
-		{
-			ID:         28,
-			UserID:     4,
-			DeviceID:   "asdf12341e73b76df6e99d0d713133c3e078418f",
-			Title:      "iPad mini 2 (Wi-Fi)",
-			CreatedAt:  "2015-03-19T13:25:43.487Z",
-			UpdatedAt:  "2015-03-19T13:25:43.487Z",
-			DeviceType: "ios",
-		},
+var testDevices = []TestDevice{
+	{
+		ID:         24,
+		UserID:     4,
+		DeviceID:   "asdf12345ad9b298cb9a9f28555c49573d8bc322",
+		Title:      "iPhone 6",
+		CreatedAt:  "2015-03-13T16:16:13.665Z",
+		UpdatedAt:  "2015-03-13T16:16:13.665Z",
+		DeviceType: "ios",
+	},
+	{
+		ID:         28,
+		UserID:     4,
+		DeviceID:   "asdf12341e73b76df6e99d0d713133c3e078418f",
+		Title:      "iPad mini 2 (Wi-Fi)",
+		CreatedAt:  "2015-03-19T13:25:43.487Z",
+		UpdatedAt:  "2015-03-19T13:25:43.487Z",
+		DeviceType: "ios",
 	},
 }
 
-const testSessionBasedConnectionResponseBody = `{
+var testConnectionOnlyDevices = AppleDeveloperConnection{
+	SessionConnection: nil,
+	JWTConnection:     nil,
+	TestDevices:       testDevices,
+}
+
+const testSessionConnectionResponseBody = `{
     "apple_id": "example@example.io",
     "password": "highSecurityPassword",
     "connection_expiry_date": "2019-04-06T12:04:59.000Z",
@@ -94,36 +96,38 @@ const testFastlaneSession = `---
 
 `
 
-var testSessionBasedConnection = AppleDeveloperConnection{
-	SessionBasedConnection: &SessionBasedConnection{
-		AppleID:              "example@example.io",
-		Password:             "highSecurityPassword",
-		ConnectionExpiryDate: "2019-04-06T12:04:59.000Z",
-		SessionCookies: map[string][]cookie{
-			"https://idmsa.apple.com": {
-				{
-					Name:     "DES58b0eba556d80ed2b98707e15ffafd344",
-					Path:     "/",
-					Value:    "HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT",
-					Domain:   "idmsa.apple.com",
-					Secure:   true,
-					Expires:  "2019-04-06T12:04:59Z",
-					MaxAge:   2592000,
-					Httponly: true,
-				},
-				{
-					Name:     "myacinfo",
-					Path:     "/",
-					Value:    "DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc",
-					Domain:   "apple.com",
-					Secure:   true,
-					Httponly: true,
-				},
+var testSessionConnection = SessionConnection{
+	AppleID:              "example@example.io",
+	Password:             "highSecurityPassword",
+	ConnectionExpiryDate: "2019-04-06T12:04:59.000Z",
+	SessionCookies: map[string][]cookie{
+		"https://idmsa.apple.com": {
+			{
+				Name:     "DES58b0eba556d80ed2b98707e15ffafd344",
+				Path:     "/",
+				Value:    "HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT",
+				Domain:   "idmsa.apple.com",
+				Secure:   true,
+				Expires:  "2019-04-06T12:04:59Z",
+				MaxAge:   2592000,
+				Httponly: true,
+			},
+			{
+				Name:     "myacinfo",
+				Path:     "/",
+				Value:    "DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc",
+				Domain:   "apple.com",
+				Secure:   true,
+				Httponly: true,
 			},
 		},
 	},
-	JWTConnection: nil,
-	TestDevices:   nil,
+}
+
+var testConnectionWithSessionConnection = AppleDeveloperConnection{
+	SessionConnection: &testSessionConnection,
+	JWTConnection:     nil,
+	TestDevices:       nil,
 }
 
 const testJWTConnectionResponseBody = `{
@@ -132,12 +136,72 @@ const testJWTConnectionResponseBody = `{
     "private_key": "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----"
 }`
 
-var testJWTConnecton = AppleDeveloperConnection{
-	SessionBasedConnection: nil,
-	JWTConnection: &JWTConnection{
-		KeyID:      "ASDF4H9LNQ",
-		IssuerID:   "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
-		PrivateKey: "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----",
-	},
-	TestDevices: nil,
+var testJWTConnection = JWTConnection{
+	KeyID:      "ASDF4H9LNQ",
+	IssuerID:   "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
+	PrivateKey: "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----",
+}
+
+var testConnectionWithJWTConnection = AppleDeveloperConnection{
+	SessionConnection: nil,
+	JWTConnection:     &testJWTConnection,
+	TestDevices:       nil,
+}
+
+const testSessionAndJWTConnectionResponseBody = `{
+    "apple_id": "example@example.io",
+    "password": "highSecurityPassword",
+    "connection_expiry_date": "2019-04-06T12:04:59.000Z",
+    "session_cookies": {
+        "https://idmsa.apple.com": [
+            {
+                "name": "DES58b0eba556d80ed2b98707e15ffafd344",
+                "path": "/",
+                "value": "HSARMTKNSRVTWFlaFrGQTmfmFBwJuiX/aaaaaaaaa+A7FbJa4V8MmWijnJknnX06ME0KrI9V8vFg==SRVT",
+                "domain": "idmsa.apple.com",
+                "secure": true,
+                "expires": "2019-04-06T12:04:59Z",
+                "max_age": 2592000,
+                "httponly": true
+            },
+            {
+                "name": "myacinfo",
+                "path": "/",
+                "value": "DAWTKNV26a0a6db3ae43acd203d0d03e8bc45000cd4bdc668e90953f22ca3b36eaab0e18634660a10cf28cc65d8ddf633c017de09477dfb18c8a3d6961f96cbbf064be616e80cee62d3d7f39a485bf826377c5b5dbbfc4a97dcdb462052db73a3a1d9b4a325d5bdd496190b3088878cecce17e4d6db9230e0575cfbe7a8754d1de0c937080ef84569b6e4a75237c2ec01cf07db060a11d92e7220707dd00a2a565ee9e06074d8efa6a1b7f83db3e1b2acdafb5fc0708443e77e6d71e168ae2a83b848122264b2da5cadfd9e451f9fe3f6eebc71904d4bc36acc528cc2a844d4f2eb527649a69523756ec9955457f704c28a3b6b9f97d6df900bd60044d5bc50408260f096954f03c53c16ac40a796dc439b859f882a50390b1c7517a9f4479fb1ce9ba2db241d6b8f2eb127c46ef96e0ccccccccc",
+                "domain": "apple.com",
+                "secure": true,
+                "httponly": true
+            }
+        ]
+    },
+    "key_id": "ASDF4H9LNQ",
+    "issuer_id": "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----",
+    "test_devices":[
+        {
+           "id":24,
+           "user_id":4,
+           "device_identifier":"asdf12345ad9b298cb9a9f28555c49573d8bc322",
+           "title":"iPhone 6",
+           "created_at":"2015-03-13T16:16:13.665Z",
+           "updated_at":"2015-03-13T16:16:13.665Z",
+           "device_type":"ios"
+        },
+        {
+            "id":28,
+            "user_id":4,
+            "device_identifier":"asdf12341e73b76df6e99d0d713133c3e078418f",
+            "title":"iPad mini 2 (Wi-Fi)",
+            "created_at":"2015-03-19T13:25:43.487Z",
+            "updated_at":"2015-03-19T13:25:43.487Z",
+            "device_type":"ios"
+        }
+    ]
+}
+`
+
+var testConnectionWithSessionAndJWTConnection = AppleDeveloperConnection{
+	SessionConnection: &testSessionConnection,
+	JWTConnection:     &testJWTConnection,
+	TestDevices:       testDevices,
 }

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -25,6 +25,8 @@ const testDevicesResponseBody = `{
 `
 
 var testDevices = AppleDeveloperConnection{
+	SessionBasedConnection: nil,
+	JWTConnection:          nil,
 	TestDevices: []TestDevice{
 		{
 			ID:         24,
@@ -120,4 +122,22 @@ var testSessionBasedConnection = AppleDeveloperConnection{
 			},
 		},
 	},
+	JWTConnection: nil,
+	TestDevices:   nil,
+}
+
+const testJWTConnectionResponseBody = `{
+    "key_id": "ASDF4H9LNQ",
+    "issuer_id": "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----"
+}`
+
+var testJWTConnecton = AppleDeveloperConnection{
+	SessionBasedConnection: nil,
+	JWTConnection: &JWTConnection{
+		KeyID:      "ASDF4H9LNQ",
+		IssuerID:   "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
+		PrivateKey: "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----",
+	},
+	TestDevices: nil,
 }

--- a/main.go
+++ b/main.go
@@ -433,11 +433,11 @@ func main() {
 			handleSessionDataError(err)
 		}
 
-		if conn != nil && conn.SessionBasedConnection != nil {
+		if conn != nil && conn.SessionConnection != nil {
 			fmt.Println()
 			log.Infof("Connected session-based Apple Developer Portal Account found")
 
-			sessionConn := conn.SessionBasedConnection
+			sessionConn := conn.SessionConnection
 
 			if sessionConn.AppleID != cfg.ItunesConnectUser {
 				log.Warnf("Connected Apple Developer and App Store login account missmatch")

--- a/main.go
+++ b/main.go
@@ -433,15 +433,17 @@ func main() {
 			handleSessionDataError(err)
 		}
 
-		if conn != nil && conn.AppleID != "" {
+		if conn != nil && conn.SessionBasedConnection != nil {
 			fmt.Println()
 			log.Infof("Connected session-based Apple Developer Portal Account found")
 
-			if conn.AppleID != cfg.ItunesConnectUser {
+			sessionConn := conn.SessionBasedConnection
+
+			if sessionConn.AppleID != cfg.ItunesConnectUser {
 				log.Warnf("Connected Apple Developer and App Store login account missmatch")
-			} else if expiry := conn.Expiry(); expiry != nil && conn.Expired() {
+			} else if expiry := sessionConn.Expiry(); expiry != nil && sessionConn.Expired() {
 				log.Warnf("TFA session expired on %s", expiry.String())
-			} else if session, err := conn.FastlaneLoginSession(); err != nil {
+			} else if session, err := sessionConn.FastlaneLoginSession(); err != nil {
 				handleSessionDataError(err)
 			} else {
 				fastlaneSession = session


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires PATCH [version update](https://semver.org/)

### Context

Unify Bitrise Apple Developer Connection handling in `devportalservice` package.

Currently, the connection handling is duplicated across multiple steps:
- https://github.com/bitrise-steplib/steps-deploy-to-itunesconnect-deliver/tree/2.19.0/devportalservice
- https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/tree/0.1.7/devportaldata

Resolves: https://bitrise.atlassian.net/browse/STEP-387

### Changes

This PR adds support for accessing both that API key and Apple ID based Bitrise Apple Developer Connection in a single package, which we can reuse across the related steps. 

