### PR TITLE
Step 384 conn rename

### DIFF
--- a/appleauth/auth_source.go
+++ b/appleauth/auth_source.go
@@ -37,12 +37,12 @@ func (*ConnectionAPIKeySource) Description() string {
 
 // Fetch ...
 func (*ConnectionAPIKeySource) Fetch(conn *devportalservice.AppleDeveloperConnection, inputs Inputs) (*Credentials, error) {
-	if conn == nil || conn.JWTConnection == nil { // Not configured
+	if conn == nil || conn.APIKeyConnection == nil { // Not configured
 		return nil, nil
 	}
 
 	return &Credentials{
-		APIKey: conn.JWTConnection,
+		APIKey: conn.APIKeyConnection,
 	}, nil
 }
 
@@ -68,7 +68,7 @@ func (*InputAPIKeySource) Fetch(conn *devportalservice.AppleDeveloperConnection,
 	}
 
 	return &Credentials{
-		APIKey: &devportalservice.JWTConnection{
+		APIKey: &devportalservice.APIKeyConnection{
 			IssuerID:   inputs.APIIssuer,
 			KeyID:      keyID,
 			PrivateKey: string(privateKey),
@@ -85,14 +85,14 @@ func (*ConnectionAppleIDSource) Description() string {
 
 // Fetch ...
 func (*ConnectionAppleIDSource) Fetch(conn *devportalservice.AppleDeveloperConnection, inputs Inputs) (*Credentials, error) {
-	if conn == nil || conn.SessionConnection == nil { // No Apple ID configured
+	if conn == nil || conn.AppleIDConnection == nil { // No Apple ID configured
 		return nil, nil
 	}
 
 	return &Credentials{
 		AppleID: &AppleID{
-			Username:            conn.SessionConnection.AppleID,
-			Password:            conn.SessionConnection.Password,
+			Username:            conn.AppleIDConnection.AppleID,
+			Password:            conn.AppleIDConnection.Password,
 			Session:             "",
 			AppSpecificPassword: inputs.AppSpecificPassword,
 		},
@@ -130,23 +130,23 @@ func (*ConnectionAppleIDFastlaneSource) Description() string {
 
 // Fetch ...
 func (*ConnectionAppleIDFastlaneSource) Fetch(conn *devportalservice.AppleDeveloperConnection, inputs Inputs) (*Credentials, error) {
-	if conn == nil || conn.SessionConnection == nil { // No Apple ID configured
+	if conn == nil || conn.AppleIDConnection == nil { // No Apple ID configured
 		return nil, nil
 	}
 
-	sessionConn := conn.SessionConnection
-	if expiry := sessionConn.Expiry(); expiry != nil && sessionConn.Expired() {
+	appleIDConn := conn.AppleIDConnection
+	if expiry := appleIDConn.Expiry(); expiry != nil && appleIDConn.Expired() {
 		return nil, fmt.Errorf("2FA session saved in Bitrise Developer Connection is expired, was valid until %s", expiry.String())
 	}
-	session, err := sessionConn.FastlaneLoginSession()
+	session, err := appleIDConn.FastlaneLoginSession()
 	if err != nil {
 		return nil, fmt.Errorf("could not prepare Fastlane session cookie object: %v", err)
 	}
 
 	return &Credentials{
 		AppleID: &AppleID{
-			Username:            conn.SessionConnection.AppleID,
-			Password:            conn.SessionConnection.Password,
+			Username:            conn.AppleIDConnection.AppleID,
+			Password:            conn.AppleIDConnection.Password,
 			Session:             session,
 			AppSpecificPassword: inputs.AppSpecificPassword,
 		},

--- a/appleauth/fetch.go
+++ b/appleauth/fetch.go
@@ -10,7 +10,7 @@ import (
 // Credentials contains either Apple ID or APIKey auth info
 type Credentials struct {
 	AppleID *AppleID
-	APIKey  *devportalservice.JWTConnection
+	APIKey  *devportalservice.APIKeyConnection
 }
 
 // AppleID contains Apple ID auth info

--- a/appleauth/fetch_test.go
+++ b/appleauth/fetch_test.go
@@ -64,7 +64,7 @@ func TestSelect(t *testing.T) {
 			name: "Connection active (API Key), inputs (Apple ID)",
 			args: args{
 				devportalConnection: &devportalservice.AppleDeveloperConnection{
-					JWTConnection: &devportalservice.JWTConnection{
+					APIKeyConnection: &devportalservice.APIKeyConnection{
 						KeyID: "x", IssuerID: "y", PrivateKey: "z",
 					},
 				},
@@ -76,7 +76,7 @@ func TestSelect(t *testing.T) {
 			},
 			want: Credentials{
 				AppleID: nil,
-				APIKey: &devportalservice.JWTConnection{
+				APIKey: &devportalservice.APIKeyConnection{
 					KeyID: "x", IssuerID: "y", PrivateKey: "z",
 				},
 			},
@@ -85,7 +85,7 @@ func TestSelect(t *testing.T) {
 			name: "Connection active (API Key), inputs (Apple ID), connection not enabled",
 			args: args{
 				devportalConnection: &devportalservice.AppleDeveloperConnection{
-					JWTConnection: &devportalservice.JWTConnection{
+					APIKeyConnection: &devportalservice.APIKeyConnection{
 						KeyID: "x", IssuerID: "y", PrivateKey: "z",
 					},
 				},

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -43,7 +43,7 @@ func NewBitriseClient(client httpClient, buildURL, buildAPIToken string) *Bitris
 
 const appleDeveloperConnectionPath = "apple_developer_portal_data.json"
 
-// GetAppleDeveloperConnection fetches the Bitrise.io session-based Apple Developer connection.
+// GetAppleDeveloperConnection fetches the Bitrise.io Apple Developer connection.
 func (c *BitriseClient) GetAppleDeveloperConnection() (*AppleDeveloperConnection, error) {
 	var rawCreds []byte
 	var err error
@@ -58,8 +58,8 @@ func (c *BitriseClient) GetAppleDeveloperConnection() (*AppleDeveloperConnection
 	}
 
 	type data struct {
-		*SessionConnection
-		*JWTConnection
+		*AppleIDConnection
+		*APIKeyConnection
 		TestDevices []TestDevice `json:"test_devices"`
 	}
 	var d data
@@ -67,21 +67,21 @@ func (c *BitriseClient) GetAppleDeveloperConnection() (*AppleDeveloperConnection
 		return nil, fmt.Errorf("failed to unmarshal authentication credentials from response (%s): %s", rawCreds, err)
 	}
 
-	if d.JWTConnection != nil {
-		if d.JWTConnection.IssuerID == "" {
+	if d.APIKeyConnection != nil {
+		if d.APIKeyConnection.IssuerID == "" {
 			return nil, fmt.Errorf("invalid authentication credentials, empty issuer_id in response (%s)", rawCreds)
 		}
-		if d.JWTConnection.KeyID == "" {
+		if d.APIKeyConnection.KeyID == "" {
 			return nil, fmt.Errorf("invalid authentication credentials, empty key_id in response (%s)", rawCreds)
 		}
-		if d.JWTConnection.PrivateKey == "" {
+		if d.APIKeyConnection.PrivateKey == "" {
 			return nil, fmt.Errorf("invalid authentication credentials, empty private_key in response (%s)", rawCreds)
 		}
 	}
 
 	return &AppleDeveloperConnection{
-		SessionConnection: d.SessionConnection,
-		JWTConnection:     d.JWTConnection,
+		AppleIDConnection: d.AppleIDConnection,
+		APIKeyConnection:  d.APIKeyConnection,
 		TestDevices:       d.TestDevices,
 	}, nil
 }
@@ -131,16 +131,16 @@ type cookie struct {
 	ForDomain *bool  `json:"for_domain,omitempty"`
 }
 
-// SessionConnection represents a Bitrise.io session-based Apple Developer connection.
-type SessionConnection struct {
+// AppleIDConnection represents a Bitrise.io Apple ID-based Apple Developer connection.
+type AppleIDConnection struct {
 	AppleID              string              `json:"apple_id"`
 	Password             string              `json:"password"`
 	ConnectionExpiryDate string              `json:"connection_expiry_date"`
 	SessionCookies       map[string][]cookie `json:"session_cookies"`
 }
 
-// JWTConnection ...
-type JWTConnection struct {
+// APIKeyConnection represents a Bitrise.io API key-based Apple Developer connection.
+type APIKeyConnection struct {
 	KeyID      string `json:"key_id"`
 	IssuerID   string `json:"issuer_id"`
 	PrivateKey string `json:"private_key"`
@@ -160,13 +160,13 @@ type TestDevice struct {
 // AppleDeveloperConnection represents a Bitrise.io Apple Developer connection.
 // https://devcenter.bitrise.io/getting-started/configuring-bitrise-steps-that-require-apple-developer-account-data/
 type AppleDeveloperConnection struct {
-	SessionConnection *SessionConnection
-	JWTConnection     *JWTConnection
+	AppleIDConnection *AppleIDConnection
+	APIKeyConnection  *APIKeyConnection
 	TestDevices       []TestDevice `json:"test_devices"`
 }
 
 // PrivateKeyWithHeader adds header and footer if needed
-func (cred *JWTConnection) PrivateKeyWithHeader() string {
+func (cred *APIKeyConnection) PrivateKeyWithHeader() string {
 	if strings.HasPrefix(cred.PrivateKey, "-----BEGIN PRIVATE KEY----") {
 		return cred.PrivateKey
 	}
@@ -178,18 +178,18 @@ func (cred *JWTConnection) PrivateKeyWithHeader() string {
 	)
 }
 
-// Expiry returns the expiration of the Bitrise session-based Apple Developer connection.
-func (c *SessionConnection) Expiry() *time.Time {
+// Expiry returns the expiration of the Bitrise Apple ID-based Apple Developer connection.
+func (c *AppleIDConnection) Expiry() *time.Time {
 	t, err := time.Parse(time.RFC3339, c.ConnectionExpiryDate)
 	if err != nil {
-		log.Warnf("Could not parse session-based connection expiry date: %s", err)
+		log.Warnf("Could not parse Apple ID session expiry date: %s", err)
 		return nil
 	}
 	return &t
 }
 
-// Expired returns whether the Bitrise session-based Apple Developer connection is expired.
-func (c *SessionConnection) Expired() bool {
+// Expired returns whether the Bitrise Apple ID-based Apple Developer connection is expired.
+func (c *AppleIDConnection) Expired() bool {
 	expiry := c.Expiry()
 	if expiry == nil {
 		return false
@@ -199,7 +199,7 @@ func (c *SessionConnection) Expired() bool {
 
 // FastlaneLoginSession returns the Apple ID login session in a ruby/object:HTTP::Cookie format.
 // The session can be used as a value for FASTLANE_SESSION environment variable: https://docs.fastlane.tools/best-practices/continuous-integration/#two-step-or-two-factor-auth.
-func (c *SessionConnection) FastlaneLoginSession() (string, error) {
+func (c *AppleIDConnection) FastlaneLoginSession() (string, error) {
 	var rubyCookies []string
 	for _, cookie := range c.SessionCookies["https://idmsa.apple.com"] {
 		if rubyCookies == nil {

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -43,6 +43,18 @@ func NewBitriseClient(client httpClient, buildURL, buildAPIToken string) *Bitris
 
 const appleDeveloperConnectionPath = "apple_developer_portal_data.json"
 
+func privateKeyWithHeader(privateKey string) string {
+	if strings.HasPrefix(privateKey, "-----BEGIN PRIVATE KEY----") {
+		return privateKey
+	}
+
+	return fmt.Sprint(
+		"-----BEGIN PRIVATE KEY-----\n",
+		privateKey,
+		"\n-----END PRIVATE KEY-----",
+	)
+}
+
 // GetAppleDeveloperConnection fetches the Bitrise.io Apple Developer connection.
 func (c *BitriseClient) GetAppleDeveloperConnection() (*AppleDeveloperConnection, error) {
 	var rawCreds []byte
@@ -77,6 +89,8 @@ func (c *BitriseClient) GetAppleDeveloperConnection() (*AppleDeveloperConnection
 		if d.APIKeyConnection.PrivateKey == "" {
 			return nil, fmt.Errorf("invalid authentication credentials, empty private_key in response (%s)", rawCreds)
 		}
+
+		d.APIKeyConnection.PrivateKey = privateKeyWithHeader(d.APIKeyConnection.PrivateKey)
 	}
 
 	return &AppleDeveloperConnection{
@@ -163,19 +177,6 @@ type AppleDeveloperConnection struct {
 	AppleIDConnection *AppleIDConnection
 	APIKeyConnection  *APIKeyConnection
 	TestDevices       []TestDevice `json:"test_devices"`
-}
-
-// PrivateKeyWithHeader adds header and footer if needed
-func (cred *APIKeyConnection) PrivateKeyWithHeader() string {
-	if strings.HasPrefix(cred.PrivateKey, "-----BEGIN PRIVATE KEY----") {
-		return cred.PrivateKey
-	}
-
-	return fmt.Sprint(
-		"-----BEGIN PRIVATE KEY-----\n",
-		cred.PrivateKey,
-		"\n-----END PRIVATE KEY-----",
-	)
 }
 
 // Expiry returns the expiration of the Bitrise Apple ID-based Apple Developer connection.

--- a/devportalservice/devportalservice_test.go
+++ b/devportalservice/devportalservice_test.go
@@ -38,30 +38,30 @@ func TestGetAppleDeveloperConnection(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Session-based Apple Developer Connection set for the build",
+			name: "Apple ID-based Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testSessionConnectionResponseBody)),
+				Body:       ioutil.NopCloser(strings.NewReader(testAppleIDConnectionResponseBody)),
 			},
-			want:    &testConnectionWithSessionConnection,
+			want:    &testConnectionWithAppleIDConnection,
 			wantErr: false,
 		},
 		{
-			name: "JWT Apple Developer Connection set for the build",
+			name: "API key Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testJWTConnectionResponseBody)),
+				Body:       ioutil.NopCloser(strings.NewReader(testAPIKeyConnectionResponseBody)),
 			},
-			want:    &testConnectionWithJWTConnection,
+			want:    &testConnectionWithAPIKeyConnection,
 			wantErr: false,
 		},
 		{
-			name: "Session-based and JWT Apple Developer Connection set for the build, test device available",
+			name: "Apple ID-based and API key Apple Developer Connection set for the build, test device available",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testSessionAndJWTConnectionResponseBody)),
+				Body:       ioutil.NopCloser(strings.NewReader(testAppleIDAndAPIKeyConnectionResponseBody)),
 			},
-			want:    &testConnectionWithSessionAndJWTConnection,
+			want:    &testConnectionWithAppleIDAndAPIKeyConnection,
 			wantErr: false,
 		},
 	}
@@ -75,7 +75,7 @@ func TestGetAppleDeveloperConnection(t *testing.T) {
 	}
 }
 
-func TestSessionEnvValue(t *testing.T) {
+func TestFastlaneLoginSession(t *testing.T) {
 	tests := []struct {
 		name string
 
@@ -95,10 +95,10 @@ func TestSessionEnvValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Session-based Apple Developer Connection set for the build",
+			name: "Apple ID-based Apple Developer Connection set for the build",
 			response: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader(testSessionConnectionResponseBody)),
+				Body:       ioutil.NopCloser(strings.NewReader(testAppleIDConnectionResponseBody)),
 			},
 			want:    testFastlaneSession,
 			wantErr: false,
@@ -111,17 +111,17 @@ func TestSessionEnvValue(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.want == "" {
-				require.Nil(t, conn.SessionConnection)
+				require.Nil(t, conn.AppleIDConnection)
 				return
 			}
 
-			got, err := conn.SessionConnection.FastlaneLoginSession()
+			got, err := conn.AppleIDConnection.FastlaneLoginSession()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SessionData() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FastlaneLoginSession() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("SessionData() = %v, want %v", got, tt.want)
+				t.Errorf("FastlaneLoginSession() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -46,12 +46,12 @@ var testDevices = []TestDevice{
 }
 
 var testConnectionOnlyDevices = AppleDeveloperConnection{
-	SessionConnection: nil,
-	JWTConnection:     nil,
+	AppleIDConnection: nil,
+	APIKeyConnection:  nil,
 	TestDevices:       testDevices,
 }
 
-const testSessionConnectionResponseBody = `{
+const testAppleIDConnectionResponseBody = `{
     "apple_id": "example@example.io",
     "password": "highSecurityPassword",
     "connection_expiry_date": "2019-04-06T12:04:59.000Z",
@@ -96,7 +96,7 @@ const testFastlaneSession = `---
 
 `
 
-var testSessionConnection = SessionConnection{
+var testAppleIDConnection = AppleIDConnection{
 	AppleID:              "example@example.io",
 	Password:             "highSecurityPassword",
 	ConnectionExpiryDate: "2019-04-06T12:04:59.000Z",
@@ -124,31 +124,31 @@ var testSessionConnection = SessionConnection{
 	},
 }
 
-var testConnectionWithSessionConnection = AppleDeveloperConnection{
-	SessionConnection: &testSessionConnection,
-	JWTConnection:     nil,
+var testConnectionWithAppleIDConnection = AppleDeveloperConnection{
+	AppleIDConnection: &testAppleIDConnection,
+	APIKeyConnection:  nil,
 	TestDevices:       nil,
 }
 
-const testJWTConnectionResponseBody = `{
+const testAPIKeyConnectionResponseBody = `{
     "key_id": "ASDF4H9LNQ",
     "issuer_id": "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
     "private_key": "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----"
 }`
 
-var testJWTConnection = JWTConnection{
+var testAPIKeyConnection = APIKeyConnection{
 	KeyID:      "ASDF4H9LNQ",
 	IssuerID:   "asdf1234-7325-47e3-e053-5b8c7c11a4d1",
 	PrivateKey: "-----BEGIN PRIVATE KEY-----\nASdf1234MBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9O4G/HVLgSqc2i7x\nasDF12346UNzKCEwOfQ1ixC0G9agCgYIKoZIzj0DAQehRANCAARcJQItGFcefLRc\naSDf1234ka9BMpRjjr3NWyCWl817HCdXXckuc22RjnKxRnYMBBDv8zPDX0k9TbST\nacgZ04Gg\n-----END PRIVATE KEY-----",
 }
 
-var testConnectionWithJWTConnection = AppleDeveloperConnection{
-	SessionConnection: nil,
-	JWTConnection:     &testJWTConnection,
+var testConnectionWithAPIKeyConnection = AppleDeveloperConnection{
+	AppleIDConnection: nil,
+	APIKeyConnection:  &testAPIKeyConnection,
 	TestDevices:       nil,
 }
 
-const testSessionAndJWTConnectionResponseBody = `{
+const testAppleIDAndAPIKeyConnectionResponseBody = `{
     "apple_id": "example@example.io",
     "password": "highSecurityPassword",
     "connection_expiry_date": "2019-04-06T12:04:59.000Z",
@@ -200,8 +200,8 @@ const testSessionAndJWTConnectionResponseBody = `{
 }
 `
 
-var testConnectionWithSessionAndJWTConnection = AppleDeveloperConnection{
-	SessionConnection: &testSessionConnection,
-	JWTConnection:     &testJWTConnection,
+var testConnectionWithAppleIDAndAPIKeyConnection = AppleDeveloperConnection{
+	AppleIDConnection: &testAppleIDConnection,
+	APIKeyConnection:  &testAPIKeyConnection,
 	TestDevices:       testDevices,
 }

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func main() {
 			handleSessionDataError(err)
 		}
 
-		if conn == nil || (conn.JWTConnection == nil && conn.SessionConnection == nil) {
+		if conn == nil || (conn.APIKeyConnection == nil && conn.AppleIDConnection == nil) {
 			fmt.Println()
 			log.Debugf("%s", notConnected)
 		}


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires no [version update](https://semver.org/)

### Context

Rename connection structs.

Contributes to: https://bitrise.atlassian.net/browse/STEP-384

### Changes

- Rename JWTConnection to APIKeyConnection
- Rename SessionConnection to AppleIDConnection
-  Fix private key header early
