### PR TITLE
Update TFA session expiry handling.

### DIFF
--- a/appleauth/auth_source.go
+++ b/appleauth/auth_source.go
@@ -2,6 +2,7 @@ package appleauth
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/bitrise-steplib/steps-deploy-to-itunesconnect-deliver/devportalservice"
 )
@@ -135,8 +136,8 @@ func (*ConnectionAppleIDFastlaneSource) Fetch(conn *devportalservice.AppleDevelo
 	}
 
 	appleIDConn := conn.AppleIDConnection
-	if expiry := appleIDConn.Expiry(); expiry != nil && appleIDConn.Expired() {
-		return nil, fmt.Errorf("2FA session saved in Bitrise Developer Connection is expired, was valid until %s", expiry.String())
+	if appleIDConn.SessionExpiryDate != nil && appleIDConn.SessionExpiryDate.Before(time.Now()) {
+		return nil, fmt.Errorf("2FA session saved in Bitrise Developer Connection is expired, was valid until %s", appleIDConn.SessionExpiryDate.String())
 	}
 	session, err := appleIDConn.FastlaneLoginSession()
 	if err != nil {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -67,16 +67,16 @@ workflows:
     steps:
     - path::./:
         inputs:
-          - connection: api_key
-          - api_key_path: ""
-          - api_issuer: ""
-          - team_id: ""
-          - app_id: $ITUNES_CONNECT_APP_ID
-          - skip_screenshots: "no"
-          - skip_metadata: "yes"
-          - submit_for_review: "no"
-          - fastlane_version: "latest"
-          - verbose_log: "yes"
+        - connection: api_key
+        - api_key_path: ""
+        - api_issuer: ""
+        - team_id: ""
+        - app_id: $ITUNES_CONNECT_APP_ID
+        - skip_screenshots: "no"
+        - skip_metadata: "yes"
+        - submit_for_review: "no"
+        - fastlane_version: "latest"
+        - verbose_log: "yes"
 
   test-api-key-input-auth:
     title: Test API key Step Input authentication
@@ -85,16 +85,16 @@ workflows:
     steps:
     - path::./:
         inputs:
-          - connection: "off"
-          - api_key_path: $ITUNES_CONNECT_API_KEY_PATH
-          - api_issuer: $ITUNES_CONNECT_API_KEY_ISSUER
-          - team_id: ""
-          - app_id: $ITUNES_CONNECT_APP_ID
-          - skip_screenshots: "no"
-          - skip_metadata: "yes"
-          - submit_for_review: "no"
-          - fastlane_version: "latest"
-          - verbose_log: "yes"
+        - connection: "off"
+        - api_key_path: $ITUNES_CONNECT_API_KEY_PATH
+        - api_issuer: $ITUNES_CONNECT_API_KEY_ISSUER
+        - team_id: ""
+        - app_id: $ITUNES_CONNECT_APP_ID
+        - skip_screenshots: "no"
+        - skip_metadata: "yes"
+        - submit_for_review: "no"
+        - fastlane_version: "latest"
+        - verbose_log: "yes"
 
   prepare-test:
     title: Prepare test

--- a/devportalservice/devportalservice.go
+++ b/devportalservice/devportalservice.go
@@ -147,10 +147,10 @@ type cookie struct {
 
 // AppleIDConnection represents a Bitrise.io Apple ID-based Apple Developer connection.
 type AppleIDConnection struct {
-	AppleID              string              `json:"apple_id"`
-	Password             string              `json:"password"`
-	ConnectionExpiryDate string              `json:"connection_expiry_date"`
-	SessionCookies       map[string][]cookie `json:"session_cookies"`
+	AppleID           string              `json:"apple_id"`
+	Password          string              `json:"password"`
+	SessionExpiryDate *time.Time          `json:"connection_expiry_date"`
+	SessionCookies    map[string][]cookie `json:"session_cookies"`
 }
 
 // APIKeyConnection represents a Bitrise.io API key-based Apple Developer connection.
@@ -162,13 +162,13 @@ type APIKeyConnection struct {
 
 // TestDevice ...
 type TestDevice struct {
-	ID         int    `json:"id"`
-	UserID     int    `json:"user_id"`
-	DeviceID   string `json:"device_identifier"`
-	Title      string `json:"title"`
-	CreatedAt  string `json:"created_at"`
-	UpdatedAt  string `json:"updated_at"`
-	DeviceType string `json:"device_type"`
+	ID         int       `json:"id"`
+	UserID     int       `json:"user_id"`
+	DeviceID   string    `json:"device_identifier"`
+	Title      string    `json:"title"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	DeviceType string    `json:"device_type"`
 }
 
 // AppleDeveloperConnection represents a Bitrise.io Apple Developer connection.
@@ -177,25 +177,6 @@ type AppleDeveloperConnection struct {
 	AppleIDConnection *AppleIDConnection
 	APIKeyConnection  *APIKeyConnection
 	TestDevices       []TestDevice `json:"test_devices"`
-}
-
-// Expiry returns the expiration of the Bitrise Apple ID-based Apple Developer connection.
-func (c *AppleIDConnection) Expiry() *time.Time {
-	t, err := time.Parse(time.RFC3339, c.ConnectionExpiryDate)
-	if err != nil {
-		log.Warnf("Could not parse Apple ID session expiry date: %s", err)
-		return nil
-	}
-	return &t
-}
-
-// Expired returns whether the Bitrise Apple ID-based Apple Developer connection is expired.
-func (c *AppleIDConnection) Expired() bool {
-	expiry := c.Expiry()
-	if expiry == nil {
-		return false
-	}
-	return expiry.Before(time.Now())
 }
 
 // FastlaneLoginSession returns the Apple ID login session in a ruby/object:HTTP::Cookie format.

--- a/devportalservice/devportalservice_testdata.go
+++ b/devportalservice/devportalservice_testdata.go
@@ -1,5 +1,20 @@
 package devportalservice
 
+import (
+	"time"
+)
+
+func toTime(str string) *time.Time {
+	if str == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}
+
 const testDevicesResponseBody = `{
    "test_devices":[
       {
@@ -30,8 +45,8 @@ var testDevices = []TestDevice{
 		UserID:     4,
 		DeviceID:   "asdf12345ad9b298cb9a9f28555c49573d8bc322",
 		Title:      "iPhone 6",
-		CreatedAt:  "2015-03-13T16:16:13.665Z",
-		UpdatedAt:  "2015-03-13T16:16:13.665Z",
+		CreatedAt:  *toTime("2015-03-13T16:16:13.665Z"),
+		UpdatedAt:  *toTime("2015-03-13T16:16:13.665Z"),
 		DeviceType: "ios",
 	},
 	{
@@ -39,8 +54,8 @@ var testDevices = []TestDevice{
 		UserID:     4,
 		DeviceID:   "asdf12341e73b76df6e99d0d713133c3e078418f",
 		Title:      "iPad mini 2 (Wi-Fi)",
-		CreatedAt:  "2015-03-19T13:25:43.487Z",
-		UpdatedAt:  "2015-03-19T13:25:43.487Z",
+		CreatedAt:  *toTime("2015-03-19T13:25:43.487Z"),
+		UpdatedAt:  *toTime("2015-03-19T13:25:43.487Z"),
 		DeviceType: "ios",
 	},
 }
@@ -97,9 +112,9 @@ const testFastlaneSession = `---
 `
 
 var testAppleIDConnection = AppleIDConnection{
-	AppleID:              "example@example.io",
-	Password:             "highSecurityPassword",
-	ConnectionExpiryDate: "2019-04-06T12:04:59.000Z",
+	AppleID:           "example@example.io",
+	Password:          "highSecurityPassword",
+	SessionExpiryDate: toTime("2019-04-06T12:04:59.000Z"),
 	SessionCookies: map[string][]cookie{
 		"https://idmsa.apple.com": {
 			{


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Currently, TFA session expiry check is called even if the account has no TFA enabled, this results in a misleading log:

`Could not parse Apple ID session expiry date: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"`

### Changes

- change DTOs time-related fields type to `time.Time`.
- fix spacing in bitrise.yml

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
