### PR TITLE
[SWAT-784] Workaround for iTMSTransporter 3.0+fastlane

### DIFF
--- a/fastlane.go
+++ b/fastlane.go
@@ -3,11 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-xcode/appleauth"
 )
 
@@ -69,19 +65,8 @@ func FastlaneAuthParams(authConfig appleauth.Credentials) (FastlaneParams, error
 			return FastlaneParams{}, fmt.Errorf("failed to marshal Fastane API Key configuration: %v", err)
 		}
 
-		tmpDir, err := pathutil.NormalizedOSTempDirPath("apiKey")
-		if err != nil {
-			return FastlaneParams{}, err
-		}
-		fastlaneAuthFile := filepath.Join(tmpDir, "api_key.json")
-		if err := ioutil.WriteFile(fastlaneAuthFile, privateKey, os.ModePerm); err != nil {
-			return FastlaneParams{}, err
-		}
+		envs["APP_STORE_CONNECT_API_KEY"] = string(privateKey)
 
-		args = append(args, Arg{
-			Key:   "--api_key_path",
-			Value: fastlaneAuthFile,
-		})
 		// deliver: "Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck"
 		args = append(args, Arg{
 			Key:   "--precheck_include_in_app_purchases",

--- a/fastlane.go
+++ b/fastlane.go
@@ -3,7 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
+	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-xcode/appleauth"
 )
 
@@ -65,8 +69,19 @@ func FastlaneAuthParams(authConfig appleauth.Credentials) (FastlaneParams, error
 			return FastlaneParams{}, fmt.Errorf("failed to marshal Fastane API Key configuration: %v", err)
 		}
 
-		envs["APP_STORE_CONNECT_API_KEY"] = string(privateKey)
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("apiKey")
+		if err != nil {
+			return FastlaneParams{}, err
+		}
+		fastlaneAuthFile := filepath.Join(tmpDir, "api_key.json")
+		if err := ioutil.WriteFile(fastlaneAuthFile, privateKey, os.ModePerm); err != nil {
+			return FastlaneParams{}, err
+		}
 
+		args = append(args, Arg{
+			Key:   "--api_key_path",
+			Value: fastlaneAuthFile,
+		})
 		// deliver: "Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck"
 		args = append(args, Arg{
 			Key:   "--precheck_include_in_app_purchases",

--- a/main.go
+++ b/main.go
@@ -385,7 +385,7 @@ alphanumeric characters.`)
 		options = opts
 	}
 
-	envs := []string{}
+	envs := []string{"ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD=true"}
 	if cfg.ITMSParameters != "" {
 		envs = append(envs, "DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS="+cfg.ITMSParameters)
 	}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-xcode/appleauth"
 	"github.com/bitrise-io/go-xcode/devportalservice"
+	"github.com/bitrise-io/go-xcode/utility"
 	"github.com/kballard/go-shellquote"
 )
 
@@ -385,14 +386,21 @@ alphanumeric characters.`)
 		options = opts
 	}
 
-	envs := []string{"ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD=true"}
-	if cfg.ITMSParameters != "" {
-		envs = append(envs, "DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS="+cfg.ITMSParameters)
+	version, err := utility.GetXcodeVersion()
+	if err != nil {
+		fail("Failed to read Xcode version: %w", err)
 	}
 
-	args := []string{
-		"deliver",
+	envs := []string{}
+	// Xcode 14 and above fastlane uses altool to upload
+	if version.MajorVersion < 14 {
+		envs = append(envs, "ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD=true")
+		if cfg.ITMSParameters != "" {
+			envs = append(envs, "DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS="+cfg.ITMSParameters)
+		}
 	}
+
+	args := []string{"deliver"}
 
 	authParams, err := FastlaneAuthParams(authConfig)
 	if err != nil {

--- a/vendor/github.com/bitrise-io/go-xcode/models/models.go
+++ b/vendor/github.com/bitrise-io/go-xcode/models/models.go
@@ -1,0 +1,8 @@
+package models
+
+// XcodebuildVersionModel ...
+type XcodebuildVersionModel struct {
+	Version      string
+	BuildVersion string
+	MajorVersion int64
+}

--- a/vendor/github.com/bitrise-io/go-xcode/utility/path.go
+++ b/vendor/github.com/bitrise-io/go-xcode/utility/path.go
@@ -1,0 +1,39 @@
+package utility
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// FindFileInAppDir ...
+func FindFileInAppDir(appDir, fileName string) (string, error) {
+	filePth := filepath.Join(appDir, fileName)
+	if exist, err := pathutil.IsPathExists(filePth); err != nil {
+		return "", err
+	} else if exist {
+		return filePth, nil
+	}
+	// ---
+
+	// It's somewhere else - let's find it!
+	apps, err := pathutil.ListEntries(appDir, pathutil.ExtensionFilter(".app", true))
+	if err != nil {
+		return "", err
+	}
+
+	for _, app := range apps {
+		pths, err := pathutil.ListEntries(app, pathutil.BaseFilter(fileName, true))
+		if err != nil {
+			return "", err
+		}
+
+		if len(pths) > 0 {
+			return pths[0], nil
+		}
+	}
+	// ---
+
+	return "", fmt.Errorf("failed to find %s", fileName)
+}

--- a/vendor/github.com/bitrise-io/go-xcode/utility/utility.go
+++ b/vendor/github.com/bitrise-io/go-xcode/utility/utility.go
@@ -1,0 +1,51 @@
+package utility
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-xcode/models"
+)
+
+func getXcodeVersionFromXcodebuildOutput(outStr string) (models.XcodebuildVersionModel, error) {
+	split := strings.Split(outStr, "\n")
+	if len(split) == 0 {
+		return models.XcodebuildVersionModel{}, fmt.Errorf("failed to parse xcodebuild version output (%s)", outStr)
+	}
+
+	xcodebuildVersion := split[0]
+	buildVersion := split[1]
+
+	split = strings.Split(xcodebuildVersion, " ")
+	if len(split) != 2 {
+		return models.XcodebuildVersionModel{}, fmt.Errorf("failed to parse xcodebuild version output (%s)", outStr)
+	}
+
+	version := split[1]
+
+	split = strings.Split(version, ".")
+	majorVersionStr := split[0]
+
+	majorVersion, err := strconv.ParseInt(majorVersionStr, 10, 32)
+	if err != nil {
+		return models.XcodebuildVersionModel{}, fmt.Errorf("failed to parse xcodebuild version output (%s), error: %s", outStr, err)
+	}
+
+	return models.XcodebuildVersionModel{
+		Version:      xcodebuildVersion,
+		BuildVersion: buildVersion,
+		MajorVersion: majorVersion,
+	}, nil
+}
+
+// GetXcodeVersion ...
+func GetXcodeVersion() (models.XcodebuildVersionModel, error) {
+	cmd := command.New("xcodebuild", "-version")
+	outStr, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return models.XcodebuildVersionModel{}, fmt.Errorf("xcodebuild -version failed, err: %s, details: %s", err, outStr)
+	}
+	return getXcodeVersionFromXcodebuildOutput(outStr)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,6 +19,8 @@ github.com/bitrise-io/go-utils/retry
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/devportalservice
+github.com/bitrise-io/go-xcode/models
+github.com/bitrise-io/go-xcode/utility
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/hashicorp/go-cleanhttp v0.5.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Workaround for https://github.com/fastlane/fastlane/issues/20741.
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Resolves: https://bitrise.atlassian.net/browse/SWAT-784

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

- Added Xcode version check, do not pass Transporter params if altool is used. This is needed to work around [issue](https://app.bitrise.io/build/42c72af6-a216-4bef-970b-a8e6cf4f66be):
```
[11:00:03]: [altool] 2022-10-24 11:00:03.945 *** Error: Could not determine the package’s bundle ID. The package is missing an Info.plist or the CFBundlePackageType is not ‘APPL’ or ‘FMWK’. Unable to validate your application. (-21017)
[11:00:03]: [altool]  {
[11:00:03]: [altool]     NSLocalizedDescription = "Could not determine the package\U2019s bundle ID. The package is missing an Info.plist or the CFBundlePackageType is not \U2018APPL\U2019 or \U2018FMWK\U2019.";
[11:00:03]: [altool]     NSLocalizedFailureReason = "Unable to validate your application.";
[11:00:03]: [altool] }
[11:00:03]: Application Loader output above ^
[11:00:03]: Error uploading '/tmp/[REDACTED]-27e4a0fc-d759-4a5a-869b-c51f46af1fd3.itmsp'.
[11:00:03]: Could not determine the package’s bundle ID. The package is missing an Info.plist or the CFBundlePackageType is not ‘APPL’ or ‘FMWK’. Unable to validate your application. (-21017)
[11:00:03]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
[11:00:03]: Could not download/upload from App Store Connect!
[!] Error uploading ipa file: 
 [Application Loader Error Output]: Error uploading '/tmp/[REDACTED]-27e4a0fc-d759-4a5a-869b-c51f46af1fd3.itmsp'.
[Application Loader Error Output]: Could not determine the package’s bundle ID. The package is missing an Info.plist or the CFBundlePackageType is not ‘APPL’ or ‘FMWK’. Unable to validate your application. (-21017)
[Application Loader Error Output]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
Deploy failed, error: exit status 1
```

<!-- Please list decisions that were made for this change. -->
