### PR TITLE
Add release_notes and release_notes_language inputs (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `skip_metadata` | Don't upload the metadata. This will still upload screenshots. | required | `yes` |
 | `skip_screenshots` | Don't upload the screenshots. | required | `yes` |
 | `skip_app_version_update` | Don't update the app version for submission. | required | `no` |
+| `release_notes` | The text of the localized release notes (What's New) to be uploaded for this version. **NOTE:** To upload release notes, you must also set the **Skip metadata?** (`skip_metadata`) input to `no`. If `skip_metadata` is set to `yes`, this input will be ignored. |  |  |
+| `release_notes_language` | The language/locale folder name under which to save the release notes (e.g. `en-US`, `default`, `fr-FR`). If you want the release notes to apply as the default fallback for all languages, set this to `default`. |  | `en-US` |
 | `gemfile_path` | Path to the `Gemfile` which contains the `fastlane` gem. If a `Gemfile` doesn't exist or doesn't contain the `fastlane` gem and if the **fastlane version** input isn't specified, the latest fastlane version will be used.  |  | `./Gemfile` |
 | `fastlane_version` | This option lets you specify a version of the **fastlane** gem to be installed. - `latest-stable` installs the latest stable version. - `latest` installs the latest version of fastlane including pre-release (release candidate) versions. |  | `latest-stable` |
 | `options` | Options added to the end of the `deliver` call. If you want to add more options, list those separated by space character. Example: `--skip_metadata --skip_screenshots` |  |  |

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ type Config struct {
 	SkipMetadata         string `env:"skip_metadata,opt[yes,no]"`
 	SkipScreenshots      string `env:"skip_screenshots,opt[yes,no]"`
 	SkipAppVersionUpdate string `env:"skip_app_version_update,opt[yes,no]"`
+	ReleaseNotes         string `env:"release_notes"`
+	ReleaseNotesLanguage string `env:"release_notes_language"`
 	TeamID               string `env:"team_id"`
 	TeamName             string `env:"team_name"`
 	Platform             string `env:"platform,opt[ios,osx,appletvos]"`
@@ -369,6 +371,19 @@ func main() {
 	fmt.Println()
 	log.Infof("Deploy")
 
+	if cfg.ReleaseNotes != "" {
+		path, err := writeReleaseNotes("fastlane", cfg.ReleaseNotes, cfg.ReleaseNotesLanguage)
+		if err != nil {
+			fail("Failed to write release notes: %s", err)
+		}
+
+		log.Donef("Successfully wrote release notes to %s", path)
+
+		if cfg.SkipMetadata == "yes" {
+			log.Warnf("Release notes are configured, but 'skip_metadata' is set to 'yes'. Release notes will be ignored by fastlane deliver. Please set 'skip_metadata' to 'no' to upload release notes.")
+		}
+	}
+
 	if cfg.Password != "" {
 		log.Printf(`**Note:** if your password
 contains special characters
@@ -529,4 +544,27 @@ func normalizeArtifactPath(pth string) (string, error) {
 	}
 
 	return tmpPath, nil
+}
+
+func writeReleaseNotes(baseDir, releaseNotes, language string) (string, error) {
+	if releaseNotes == "" {
+		return "", nil
+	}
+
+	lang := language
+	if lang == "" {
+		lang = "en-US"
+	}
+
+	dir := filepath.Join(baseDir, "metadata", lang)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	path := filepath.Join(dir, "release_notes.txt")
+	if err := fileutil.WriteStringToFile(path, releaseNotes); err != nil {
+		return "", fmt.Errorf("failed to write release notes to %s: %w", path, err)
+	}
+
+	return path, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/bitrise-io/go-utils/fileutil"
 )
 
 func Test_ensureFastlaneVersionAndCreateCmdSlice(t *testing.T) {
@@ -37,6 +41,72 @@ func Test_ensureFastlaneVersionAndCreateCmdSlice(t *testing.T) {
 			}
 			if got1 != tt.want1 {
 				t.Errorf("ensureFastlaneVersionAndCreateCmdSlice() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func Test_writeReleaseNotes(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "release_notes_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name         string
+		releaseNotes string
+		language     string
+		wantPath     string
+		wantContent  string
+		wantErr      bool
+	}{
+		{
+			name:         "empty release notes",
+			releaseNotes: "",
+			language:     "en-US",
+			wantPath:     "",
+			wantContent:  "",
+			wantErr:      false,
+		},
+		{
+			name:         "valid release notes with default language",
+			releaseNotes: "Some amazing update notes!",
+			language:     "",
+			wantPath:     filepath.Join(tempDir, "metadata", "en-US", "release_notes.txt"),
+			wantContent:  "Some amazing update notes!",
+			wantErr:      false,
+		},
+		{
+			name:         "valid release notes with custom language",
+			releaseNotes: "Des notes de mise à jour!",
+			language:     "fr-FR",
+			wantPath:     filepath.Join(tempDir, "metadata", "fr-FR", "release_notes.txt"),
+			wantContent:  "Des notes de mise à jour!",
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, err := writeReleaseNotes(tempDir, tt.releaseNotes, tt.language)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("writeReleaseNotes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if gotPath != tt.wantPath {
+				t.Errorf("writeReleaseNotes() gotPath = %v, want %v", gotPath, tt.wantPath)
+			}
+
+			if tt.wantPath != "" {
+				content, err := fileutil.ReadStringFromFile(gotPath)
+				if err != nil {
+					t.Errorf("failed to read written release notes file: %s", err)
+				}
+				if content != tt.wantContent {
+					t.Errorf("written file content = %v, want %v", content, tt.wantContent)
+				}
 			}
 		})
 	}

--- a/step.yml
+++ b/step.yml
@@ -224,7 +224,7 @@ inputs:
       The text of the localized release notes (What's New) to be uploaded for this version.
       **NOTE:** To upload release notes, you must also set the **Skip metadata?** (`skip_metadata`) input to `no`.
       If `skip_metadata` is set to `yes`, this input will be ignored.
-- release_notes_language: "en-US"
+- release_notes_language: en-US
   opts:
     title: Release notes language
     summary: The language of the release notes (e.g. en-US, default).

--- a/step.yml
+++ b/step.yml
@@ -216,6 +216,21 @@ inputs:
     - "yes"
     - "no"
     is_required: true
+- release_notes: ""
+  opts:
+    title: Release notes
+    summary: Localized release notes (What's New) to upload.
+    description: |-
+      The text of the localized release notes (What's New) to be uploaded for this version.
+      **NOTE:** To upload release notes, you must also set the **Skip metadata?** (`skip_metadata`) input to `no`.
+      If `skip_metadata` is set to `yes`, this input will be ignored.
+- release_notes_language: "en-US"
+  opts:
+    title: Release notes language
+    summary: The language of the release notes (e.g. en-US, default).
+    description: |-
+      The language/locale folder name under which to save the release notes (e.g. `en-US`, `default`, `fr-FR`).
+      If you want the release notes to apply as the default fallback for all languages, set this to `default`.
 - gemfile_path: ./Gemfile
   opts:
     category: Debug


### PR DESCRIPTION
### Summary
This PR adds support for specifying App Store Connect release notes (the "What's New" field, or `whatsNew` API attribute) in the Step's configuration. This directly resolves #138, which causes builds to fail during App Store review submission when release notes are not already filled in on the App Store Connect portal.

### Changes
1. **`step.yml`**:
   - Added two new inputs:
     - `release_notes`: The localized release notes text to upload for this version.
     - `release_notes_language`: The target locale directory name (defaults to `en-US`, can be set to `default`, `fr-FR`, etc.).
2. **`main.go`**:
   - Extended the `Config` struct with `ReleaseNotes` and `ReleaseNotesLanguage` inputs.
   - Refactored the file-writing logic into a modular helper function: `writeReleaseNotes(baseDir, releaseNotes, language)`.
   - Before executing Fastlane `deliver`, write the release notes to `./fastlane/metadata/<language>/release_notes.txt`.
   - Added a clear warning if a user defines `release_notes` but has `skip_metadata: "yes"` (advising them to set `skip_metadata: "no"` so Fastlane uploads it).
3. **`main_test.go`**:
   - Added extensive unit tests `Test_writeReleaseNotes` ensuring correct behavior for empty values, default paths, and custom languages.

### How it works / "Skip if missing" behavior:
By default, Fastlane `deliver` uses a **"skip if missing"** logic: if you don't provide other metadata files (e.g., `description.txt` or `keywords.txt`) inside your local `./fastlane/metadata` directory, Fastlane simply skips those fields and **preserves** whatever is currently configured on the App Store Connect web portal. 
Therefore, by writing only `./fastlane/metadata/<locale>/release_notes.txt`, we can safely update the release notes on App Store Connect without modifying or clearing any other metadata!

### Verification
- [x] All Go unit tests compile and pass successfully (`go test -v ./...`).
